### PR TITLE
Fixed your Discord invite URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
             <i class="hamburger fa-solid fa-bars"></i>
             <div class="nav-links">
                 <a href="https://github.com/WatchTubeTeam/"><i class="fa-brands fa-github"></i></a>
-                <a href="https://discord.gg/6aJUwDQz5n"><i class="fa-brands fa-discord"></i></a>
+                <a href="https://discord.gg/6RJtAWp9wJ"><i class="fa-brands fa-discord"></i></a>
                 <a href="https://apps.apple.com/gb/app/watchtube/id1599884909"><i
                         class="fa-brands fa-app-store-ios"></i></a>
             </div>


### PR DESCRIPTION
Discord URL was broken, now fixed. Either change it yourself or use this, idm.